### PR TITLE
Correction of the calculation of s:fullwidth

### DIFF
--- a/plugin/eightheader.vim
+++ b/plugin/eightheader.vim
@@ -299,7 +299,8 @@ endfunction
 
 function! EightHeaderFolds( length, align, decor, marker, str )
 
-  let s:fullwidth = winwidth( 0 ) - (&number ? &numberwidth : 0) - &foldcolumn
+  let s:numberwidthReal = strlen(string(line('$'))) + 1
+  let s:fullwidth = winwidth( 0 ) - (&number ? s:numberwidthReal : 0) - &foldcolumn
   let s:foldlines = v:foldend - v:foldstart + 1
 
   " Geting the text of foldheader from the original foldtext().


### PR DESCRIPTION
The builtin Vim variable` &numberwidth` contains 
```
Minimal number of columns to use for the line number.  Only relevant
when the 'number' or 'relativenumber' option is set or printing lines
with a line number. Since one space is always between the number and
the text, there is one less character for the number itself.
The value is the minimum width.  A bigger width is used when needed to
fit the highest line number in the buffer respectively the number of
rows in the window, depending on whether 'number' or 'relativenumber'
is set. Thus with the Vim default of 4 there is room for a line number
up to 999. When the buffer has 1000 lines five columns will be used.
``` 
according to `:help numberwidth`.
Without the proposed modification, the folds are mishandled in the case of files containing more than 999 lines.
The proposed modification takes care of that.