### PR TITLE
Correction of the calculation of s:fullwidth

### DIFF
--- a/plugin/eightheader.vim
+++ b/plugin/eightheader.vim
@@ -299,7 +299,8 @@ endfunction
 
 function! EightHeaderFolds( length, align, decor, marker, str )
 
-  let s:fullwidth = winwidth( 0 ) - (&number ? &numberwidth : 0) - &foldcolumn
+  let s:numberwidthReal = strlen(string(line('$'))) + 1
+  let s:fullwidth = winwidth( 0 ) - (&number ? s:numberwidthReal : 0) - &foldcolumn
   let s:foldlines = v:foldend - v:foldstart + 1
 
   " Geting the text of foldheader from the original foldtext().

--- a/plugin/eightheader.vim
+++ b/plugin/eightheader.vim
@@ -299,38 +299,38 @@ endfunction
 
 function! EightHeaderFolds( length, align, decor, marker, str )
 
-  let s:width = winwidth(0)
-  let s:numberwidth = max([&numberwidth, strlen(line('$')) + 1])
-  let s:numwidth = (&number || &relativenumber) ? s:numberwidth : 0
-  let s:foldwidth = str2nr(matchstr(&foldcolumn, '\d\+$'))
+  let l:width = winwidth(0)
+  let l:numberwidth = max([&numberwidth, strlen(line('$')) + 1])
+  let l:numwidth = (&number || &relativenumber) ? l:numberwidth : 0
+  let l:foldwidth = str2nr(matchstr(&foldcolumn, '\d\+$'))
 
   if &signcolumn == 'yes'
-    let s:signwidth = 2
+    let l:signwidth = 2
   elseif &signcolumn =~ 'yes'
-    let s:signwidth = &signcolumn
-    let s:signwidth = split(s:signwidth, ':')[1]
-    let s:signwidth *= 2  " each signcolumn is 2-char wide
+    let l:signwidth = &signcolumn
+    let l:signwidth = split(l:signwidth, ':')[1]
+    let l:signwidth *= 2  " each signcolumn is 2-char wide
   elseif &signcolumn == 'auto'
     let supports_sign_groups = has('nvim-0.4.2') || has('patch-8.1.614')
-    let s:signlist = execute(printf('sign place ' . (supports_sign_groups ? 'group=* ' : '') . 'buffer=%d', bufnr('')))
-    let s:signlist = split(s:signlist, "\n")
-    let s:signwidth = len(s:signlist) > 2 ? 2 : 0
+    let l:signlist = execute(printf('sign place ' . (supports_sign_groups ? 'group=* ' : '') . 'buffer=%d', bufnr('')))
+    let l:signlist = split(l:signlist, "\n")
+    let l:signwidth = len(l:signlist) > 2 ? 2 : 0
   elseif &signcolumn =~ 'auto'
-    let s:signwidth = 0
+    let l:signwidth = 0
     if len(sign_getplaced(bufnr(),{'group':'*'})[0].signs)
-      let s:signwidth = 0
+      let l:signwidth = 0
       for l:sign in sign_getplaced(bufnr(),{'group':'*'})[0].signs
         let lnum = l:sign.lnum
         let signs = len(sign_getplaced(bufnr(),{'group':'*', 'lnum':lnum})[0].signs)
-        let s:signwidth = (signs > s:signwidth ? signs : s:signwidth)
+        let l:signwidth = (signs > l:signwidth ? signs : l:signwidth)
       endfor
     endif
-    let s:signwidth *= 2   " each signcolumn is 2-char wide
+    let l:signwidth *= 2   " each signcolumn is 2-char wide
   else
-    let s:signwidth = 0
+    let l:signwidth = 0
   endif
 
-  let s:fullwidth = s:width - s:numwidth - s:foldwidth - s:signwidth
+  let s:fullwidth = l:width - l:numwidth - l:foldwidth - l:signwidth
   let s:foldlines = v:foldend - v:foldstart + 1
 
   " Geting the text of foldheader from the original foldtext().

--- a/plugin/eightheader.vim
+++ b/plugin/eightheader.vim
@@ -322,7 +322,7 @@ function! EightHeaderFolds( length, align, decor, marker, str )
       for l:sign in sign_getplaced(bufnr(),{'group':'*'})[0].signs
         let lnum = l:sign.lnum
         let signs = len(sign_getplaced(bufnr(),{'group':'*', 'lnum':lnum})[0].signs)
-        let s:signwidth = (signs > signwidth ? signs : signwidth)
+        let s:signwidth = (signs > s:signwidth ? signs : s:signwidth)
       endfor
     endif
     let s:signwidth *= 2   " each signcolumn is 2-char wide

--- a/plugin/eightheader.vim
+++ b/plugin/eightheader.vim
@@ -302,7 +302,7 @@ function! EightHeaderFolds( length, align, decor, marker, str )
   let s:width = winwidth(0)
   let s:numberwidth = max([&numberwidth, strlen(line('$')) + 1])
   let s:numwidth = (&number || &relativenumber) ? s:numberwidth : 0
-  let s:foldwidth = &foldcolumn
+  let s:foldwidth = str2nr(matchstr(&foldcolumn, '\d\+$'))
 
   if &signcolumn == 'yes'
     let s:signwidth = 2


### PR DESCRIPTION
The calculation of `s:fullwidth` had several flaws.
1) The width of the number column is not provided by the built-in Vim variable `&numberwidth` which contains only the minimal width (see `:help numberwidth`).
2) The calculation of `s:fullwidth` was not taking into account the width of the sign column.

This PR, which is based on 
[https://stackoverflow.com/questions/26315925/get-usable-window-width-in-vim-script](https://github.com/bimlas/vim-eightheader/compare/url)
should correct that.